### PR TITLE
turn on internal logging of logger's errors in NLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,5 @@ Now log4net and NLog are supported. Also Udp, Tcp and Amqp protocols are support
 * `includeStackTrace` (default: `true`)
   * Will include exception message and exception stack trace
 	
-
+* `verbose` (default: `false`)
+  * Whether to write logger's errors to the internal logger of the NLog or log4net

--- a/Source/EasyGelf.NLog.Example/NLog.config
+++ b/Source/EasyGelf.NLog.Example/NLog.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      internalLogToConsole="true" internalLogLevel="Warn">
   <extensions>
     <add assembly="EasyGelf.NLog"/>
   </extensions>
   <targets>
-    <target name="GelfUdp" xsi:type="GelfUdp" facility="Easy Gelf Example Application" remoteAddress="127.0.0.1" remotePort="12201" layout="${message}"/>
-    <target name="GelfAmqp" xsi:type="GelfAmqp" facility="Easy Gelf Example Application" connectionUri="amqp://" layout="${message}"/>
+    <target name="GelfUdp" xsi:type="GelfUdp" facility="Easy Gelf Example Application" remoteAddress="127.0.0.1" remotePort="12201" layout="${message}" verbose="true"/>
+    <target name="GelfAmqp" xsi:type="GelfAmqp" facility="Easy Gelf Example Application" connectionUri="amqp://" layout="${message}" verbose="true"/>
     <target name="console" xsi:type="Console"/>
   </targets>
 


### PR DESCRIPTION
 to simplify connectivity debugging out of the box