### PR TITLE
Make BufferedTransport close async

### DIFF
--- a/Source/EasyGelf.Core/Transports/BufferedTransport.cs
+++ b/Source/EasyGelf.Core/Transports/BufferedTransport.cs
@@ -4,50 +4,59 @@ using System.Threading;
 
 namespace EasyGelf.Core.Transports
 {
-    public sealed class BufferedTransport : ITransport
+    public sealed class BufferedTransport : ITransport, IDisposable
     {
         private readonly BlockingCollection<GelfMessage> buffer = new BlockingCollection<GelfMessage>();
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-        private readonly ManualResetEvent stopEvent = new ManualResetEvent(false);
+        private readonly IEasyGelfLogger logger;
+        private readonly ITransport transport;
 
         public BufferedTransport(IEasyGelfLogger logger, ITransport transport)
         {
-            new Thread(() =>
+            this.logger = logger;
+            this.transport = transport;
+            new Thread(PollAndSend)
+            {
+                IsBackground = true,
+                Name = "EasyGelf Buffered Transport Thread"
+            }.Start();
+        }
+
+        private void PollAndSend()
+        {
+            GelfMessage message;
+            var cancellationToken = cancellationTokenSource.Token;
+            try
+            {
+                while (buffer.TryTake(out message, -1, cancellationToken))
                 {
-                    var cancellationToken = cancellationTokenSource.Token;
-                    try
-                    {
-                        GelfMessage mesage;
-                        while (buffer.TryTake(out mesage, -1, cancellationToken))
-                        {
-                            try
-                            {
-                                transport.Send(mesage);
-                            }
-                            catch(Exception exception)
-                            {
-                                logger.Error("Cannot send message", exception);
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        GelfMessage message;
-                        while (buffer.TryTake(out message))
-                        {
-                            try
-                            {
-                                transport.Send(message);
-                            }
-                            catch (Exception exception)
-                            {
-                                logger.Error("Cannot send message", exception);
-                            }
-                        }
-                    }
-                    transport.Close();
-                    stopEvent.Set();
-                }) {IsBackground = true, Name = "EasyGelf Buffered Transport Thread"}.Start();
+                    SafeSendMessage(message);
+                }
+            }
+            catch
+            {
+                while (buffer.TryTake(out message))
+                {
+                    SafeSendMessage(message);
+                }
+            }
+
+            // Close was called. Dispose all resources
+            transport.Close();
+            buffer.Dispose();
+            cancellationTokenSource.Dispose();
+        }
+
+        private void SafeSendMessage(GelfMessage mesage)
+        {
+            try
+            {
+                transport.Send(mesage);
+            }
+            catch (Exception exception)
+            {
+                logger.Error("Cannot send message", exception);
+            }
         }
 
         public void Send(GelfMessage message)
@@ -57,10 +66,13 @@ namespace EasyGelf.Core.Transports
 
         public void Close()
         {
-            buffer.CompleteAdding();
             cancellationTokenSource.Cancel();
-            stopEvent.WaitOne();
-            stopEvent.Dispose();
+            buffer.CompleteAdding();
+        }
+
+        public void Dispose()
+        {
+            this.Close();
         }
     }
 }

--- a/Source/EasyGelf.Tests/Core/Transport/BufferedTransportTests.cs
+++ b/Source/EasyGelf.Tests/Core/Transport/BufferedTransportTests.cs
@@ -15,13 +15,15 @@ namespace EasyGelf.Tests.Core.Transport
         public void ShouldSendMessage()
         {
             var countingTransport = new SuceedCountingTransport();
-            var bufferedTransport = new BufferedTransport(new SilentLogger(), countingTransport);
-            for (var i = 0; i < MessageCount; ++i)
+            using (var bufferedTransport = new BufferedTransport(new SilentLogger(), countingTransport))
             {
-                var message = new GelfMessage();
-                bufferedTransport.Send(message);
+                for (var i = 0; i < MessageCount; ++i)
+                {
+                    var message = new GelfMessage();
+                    bufferedTransport.Send(message);
+                }
             }
-            bufferedTransport.Close();
+            
             Assert.AreEqual(MessageCount, countingTransport.Count);
         }
 
@@ -29,13 +31,15 @@ namespace EasyGelf.Tests.Core.Transport
         public void ShouldSkipMessageIfSendFailed()
         {
             var countingTransport = new FailCountingTransport();
-            var bufferedTransport = new BufferedTransport(new SilentLogger(), countingTransport);
-            for (var i = 0; i < MessageCount; ++i)
+            using (var bufferedTransport = new BufferedTransport(new SilentLogger(), countingTransport))
             {
-                var message = new GelfMessage();
-                bufferedTransport.Send(message);
+                for (var i = 0; i < MessageCount; ++i)
+                {
+                    var message = new GelfMessage();
+                    bufferedTransport.Send(message);
+                }
             }
-            bufferedTransport.Close();
+            
             Assert.AreEqual(MessageCount, countingTransport.Count);
         }
 


### PR DESCRIPTION
This code still needs testing.

Basically, the Buffered Transport can behave synchronously when an underlying/decorated TCP transport is used and there is no connection to Graylog. The .Net TCP connection can take a while to throw a connection exception, and when coupled with retries, it can take considerable time to drain the  queue and close the Buffered Transport.