### PR TITLE
It is possible to notice if Graylog connection is lost. 

### DIFF
--- a/Source/EasyGelf.Core/SilentLogger.cs
+++ b/Source/EasyGelf.Core/SilentLogger.cs
@@ -6,16 +6,34 @@ namespace EasyGelf.Core
     {
         void Error(string message, Exception exception);
         void Debug(string message);
+        void SetException(Exception e);
+        void CheckException();
     }
 
     public sealed class SilentLogger : IEasyGelfLogger
     {
+        private static Exception threadException = null;
+
         public void Error(string message, Exception exception)
         {
         }
 
         public void Debug(string message)
         {
+        }
+
+        public void SetException(Exception exception)
+        {
+            threadException = exception;
+        }
+        public void CheckException()
+        {
+            Exception e = threadException;
+            if (threadException != null)
+            {
+                threadException = null;
+                throw e;
+            }
         }
     }
 }

--- a/Source/EasyGelf.Core/Transports/BufferedTransport.cs
+++ b/Source/EasyGelf.Core/Transports/BufferedTransport.cs
@@ -27,6 +27,7 @@ namespace EasyGelf.Core.Transports
                             catch(Exception exception)
                             {
                                 logger.Error("Cannot send message", exception);
+                                logger.SetException(exception);
                             }
                         }
                     }
@@ -42,6 +43,7 @@ namespace EasyGelf.Core.Transports
                             catch (Exception exception)
                             {
                                 logger.Error("Cannot send message", exception);
+                                logger.SetException(exception);
                             }
                         }
                     }

--- a/Source/EasyGelf.Log4Net/VerboseLogger.cs
+++ b/Source/EasyGelf.Log4Net/VerboseLogger.cs
@@ -6,6 +6,7 @@ namespace EasyGelf.Log4Net
 {
     public sealed class VerboseLogger : IEasyGelfLogger
     {
+        private static Exception threadException = null;
         public void Error(string message, Exception exception)
         {
             LogLog.Error(typeof(VerboseLogger), message, exception);
@@ -14,6 +15,20 @@ namespace EasyGelf.Log4Net
         public void Debug(string message)
         {
             LogLog.Debug(typeof(VerboseLogger), message);
+        }
+        public void SetException(Exception exception)
+        {
+            threadException = exception;
+        }
+
+        public void CheckException()
+        {
+            Exception e = threadException;
+            if (threadException != null)
+            {
+                threadException = null;
+                throw e;
+            }
         }
     }
 }

--- a/Source/EasyGelf.NLog/GelfTargetBase.cs
+++ b/Source/EasyGelf.NLog/GelfTargetBase.cs
@@ -106,7 +106,9 @@ namespace EasyGelf.NLog
             catch (Exception exception)
             {
                 logger.Error("Failed to send message", exception);
+                throw;
             }
+            logger.CheckException();
         }
 
         protected override void InitializeTarget()

--- a/Source/EasyGelf.NLog/VerboseLogger.cs
+++ b/Source/EasyGelf.NLog/VerboseLogger.cs
@@ -6,6 +6,7 @@ namespace EasyGelf.NLog
 {
     public sealed class VerboseLogger : IEasyGelfLogger
     {
+        private static Exception threadException = null;
         public void Error(string message, Exception exception)
         {
             InternalLogger.Error(string.Format("{0} ---> {1}", message, exception));
@@ -14,6 +15,19 @@ namespace EasyGelf.NLog
         public void Debug(string message)
         {
             InternalLogger.Debug(message);
+        }
+        public void SetException(Exception exception)
+        {
+            threadException = exception;
+        }
+        public void CheckException()
+        {
+            Exception e = threadException;
+            if (threadException != null)
+            {
+                threadException = null;
+                throw e;
+            }
         }
     }
 }


### PR DESCRIPTION
Originally EasyGelf swallows all exceptions.

I want to use EasyGelf with TCP-protocol to get connection lost -errors.
I have NLOG fallbackgroup that should notice if Graylog connection is lost. 
In case of failure it should change to next log target.
If all errors are handled inside EasyGelf, target is never changed in NLOG fallbackgroup.

So these changes makes possible to use EasyGelf with NLOG fallbackgroup. 
