### PR TITLE
Make serializer a little more forgiving when keys collide.

### DIFF
--- a/Source/EasyGelf.Core/GelfMessageSerializer.cs
+++ b/Source/EasyGelf.Core/GelfMessageSerializer.cs
@@ -10,23 +10,40 @@ namespace EasyGelf.Core
 
     public sealed class GelfMessageSerializer : IGelfMessageSerializer
     {
+        private readonly IEasyGelfLogger _logger;
+
+        public GelfMessageSerializer(IEasyGelfLogger logger)
+        {
+            _logger = logger;
+        }
+
         public byte[] Serialize(GelfMessage message)
         {
             var duration = message.Timestamp.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             var result = new JsonObject
-                {
-                    {"version", message.Version},
-                    {"host", message.Host},
-                    {"short_message", message.ShortMessage},
-                    {"full_message", message.FullMessage},
-                    {"timestamp", Math.Round(duration.TotalSeconds, 3, MidpointRounding.AwayFromZero)},
-                    {"level", (int)message.Level}
-                };
+            {
+                {"version", message.Version},
+                {"host", message.Host},
+                {"short_message", message.ShortMessage},
+                {"full_message", message.FullMessage},
+                {"timestamp", Math.Round(duration.TotalSeconds, 3, MidpointRounding.AwayFromZero)},
+                {"level", (int) message.Level}
+            };
             foreach (var additionalField in message.AdditionalFields)
             {
                 var key = additionalField.Key;
                 var value = additionalField.Value;
-                result.Add(key.StartsWith("_") ? key : "_" + key, value);
+                var prefixedKey = key.StartsWith("_") ? key : "_" + key;
+                if (!result.ContainsKey(prefixedKey))
+                {
+                    result.Add(prefixedKey, value);
+                }
+                else
+                {
+                    _logger.Debug(string.Format(
+                        "Duplicate key {0} found.  Key collisions are resolved by favoring the first key-value to be added.",
+                        prefixedKey));
+                }
             }
             return Encoding.UTF8.GetBytes(result.ToString());
         }

--- a/Source/EasyGelf.Core/Transports/Tcp/TcpTransportFactory.cs
+++ b/Source/EasyGelf.Core/Transports/Tcp/TcpTransportFactory.cs
@@ -9,16 +9,11 @@ namespace EasyGelf.Core.Transports.Tcp
 {
     public class TcpTransportFactory
     {
-        public static ITransport Produce(TcpTransportConfiguration configuration)
+        public static ITransport Produce(TcpTransportConfiguration configuration, IEasyGelfLogger logger)
         {
-            if (configuration.Ssl)
-            {
-                return new TcpTransport(configuration, new GelfMessageSerializer(), () => new TcpSslConnection(configuration));
-            }
-            else
-            {
-                return new TcpTransport(configuration, new GelfMessageSerializer(), () => new TcpConnection(configuration));
-            }
+            return configuration.Ssl
+                ? new TcpTransport(configuration, new GelfMessageSerializer(logger), () => new TcpSslConnection(configuration))
+                : new TcpTransport(configuration, new GelfMessageSerializer(logger), () => new TcpConnection(configuration));
         }
     }
 }

--- a/Source/EasyGelf.Log4Net/GelfAmqpAppender.cs
+++ b/Source/EasyGelf.Log4Net/GelfAmqpAppender.cs
@@ -44,7 +44,7 @@ namespace EasyGelf.Log4Net
                     Persistent = Persistent,
                 };
             var encoder = new CompositeEncoder(new GZipEncoder(), new ChunkingEncoder(new MessageBasedIdGenerator(), MessageSize));
-            return new AmqpTransport(configuration, encoder, new GelfMessageSerializer());
+            return new AmqpTransport(configuration, encoder, new GelfMessageSerializer(logger));
         }
     }
 }

--- a/Source/EasyGelf.Log4Net/GelfTcpAppender.cs
+++ b/Source/EasyGelf.Log4Net/GelfTcpAppender.cs
@@ -36,7 +36,7 @@ namespace EasyGelf.Log4Net
                 Timeout = Timeout
             };
 
-            return TcpTransportFactory.Produce(configuration);
+            return TcpTransportFactory.Produce(configuration, logger);
         }
     }
 }

--- a/Source/EasyGelf.Log4Net/GelfUdpAppender.cs
+++ b/Source/EasyGelf.Log4Net/GelfUdpAppender.cs
@@ -29,7 +29,7 @@ namespace EasyGelf.Log4Net
                     RemoteAddress = RemoteAddress,
                     RemotePort = RemotePort
                 };
-            return new UdpTransport(configuration, encoder, new GelfMessageSerializer());
+            return new UdpTransport(configuration, encoder, new GelfMessageSerializer(logger));
         }
     }
 }

--- a/Source/EasyGelf.NLog.Example/EntryPoint.cs
+++ b/Source/EasyGelf.NLog.Example/EntryPoint.cs
@@ -22,7 +22,7 @@ namespace EasyGelf.NLog.Example
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Descriptive message example", ex);
+                    Log.Error(ex, "Descriptive message example");
                 }
                 
                 Thread.Sleep(TimeSpan.FromSeconds(0.5));

--- a/Source/EasyGelf.NLog/GelfAmqpTarget.cs
+++ b/Source/EasyGelf.NLog/GelfAmqpTarget.cs
@@ -46,7 +46,7 @@ namespace EasyGelf.NLog
                     RoutingKey = RoutingKey,
                     Persistent = Persistent
                 };
-            return new AmqpTransport(configuration, encoder, new GelfMessageSerializer());
+            return new AmqpTransport(configuration, encoder, new GelfMessageSerializer(logger));
         }
     }
 }

--- a/Source/EasyGelf.NLog/GelfHttpTarget.cs
+++ b/Source/EasyGelf.NLog/GelfHttpTarget.cs
@@ -34,7 +34,7 @@ namespace EasyGelf.NLog
                 Port = RemotePort
             };
 
-            return new HttpTransport(configuration, new GelfMessageSerializer());
+            return new HttpTransport(configuration, new GelfMessageSerializer(logger));
         }
     }
 }

--- a/Source/EasyGelf.NLog/GelfTcpTarget.cs
+++ b/Source/EasyGelf.NLog/GelfTcpTarget.cs
@@ -38,7 +38,7 @@ namespace EasyGelf.NLog
                 Timeout = Timeout
             };
 
-            return TcpTransportFactory.Produce(configuration);
+            return TcpTransportFactory.Produce(configuration, logger);
         }
     }
 }

--- a/Source/EasyGelf.NLog/GelfUdpTarget.cs
+++ b/Source/EasyGelf.NLog/GelfUdpTarget.cs
@@ -31,7 +31,7 @@ namespace EasyGelf.NLog
                     RemoteAddress = RemoteAddress,
                     RemotePort = RemotePort
                 };
-            return new UdpTransport(configuration, encoder, new GelfMessageSerializer());
+            return new UdpTransport(configuration, encoder, new GelfMessageSerializer(logger));
         }
     }
 }

--- a/Source/EasyGelf.Tests/Core/GelfMessageSerializerTests.cs
+++ b/Source/EasyGelf.Tests/Core/GelfMessageSerializerTests.cs
@@ -13,7 +13,7 @@ namespace EasyGelf.Tests.Core
         [SetUp]
         public void SetUp()
         {
-            serializer = new GelfMessageSerializer();
+            serializer = new GelfMessageSerializer(new SilentLogger());
         }
 
         [Test]


### PR DESCRIPTION
Thanks for sharing this project.  This PR addresses something we saw in a production environment where pushed an nlog config change that referenced MDC items in the GelfTcp target that I didn't realize were already passed in eventInfo.Properties.  That is, an MDC item had the same name as an nlog event info property.  This caused a key collision and an exception in the code that serializes to a JsonObject.  That's my bad.  But this exception also resulted in 5 retries so one predictable exception became 6 due to retry logic that is really geared toward network transport issues.  With multiple exceptions on every other log message sent to the GelfTcp target my nlog config change ended up pegging our CPU.  Why not just log this at error or debug level and move on or scope the retry logic down to transport issues?  Hope this is helpful.